### PR TITLE
fix: styles for the word input

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,13 +1,25 @@
 <template>
     <div id="divMainSettings">
         <div id="divTopSettings">
-            <ion-item class="ion-text-center" v-for="(word, index) in wordRelated.mainListOfWords" :key="index">
+            <ion-item
+                class="ion-text-center custom-background"
+                v-for="(word, index) in wordRelated.mainListOfWords"
+                :key="index"
+            >
                 <ion-label>{{ word }}</ion-label>
             </ion-item>
         </div>
         <div id="divMiddleSettings">
-            <ion-input @keydown.enter="saveWord" @focusout="saveWord" type="text" :clear-input="true"
-            label="Enter Your Own Words or Sentences" label-placement="floating" fill="outline"></ion-input>
+            <ion-input
+                class="custom-margin-top"
+                @keydown.enter="saveWord"
+                @focusout="saveWord"
+                type="text"
+                :clear-input="true"
+                label="Enter your own word(s)"
+                label-placement="floating"
+                fill="outline"
+            ></ion-input>
         </div>
     </div>
 </template>
@@ -44,6 +56,7 @@ function saveWord(event){
 }
 
 #divTopSettings {
+    margin-top: 20px;
     margin-left: auto;
     margin-right: auto;
     height: 10%;
@@ -57,5 +70,13 @@ function saveWord(event){
     height: 10%;
     width: 85%;
     /* border: 2px solid green; */
+}
+
+.custom-margin-top {
+    margin-top: 20px;
+}
+
+.custom-background {
+    --background: transparent;
 }
 </style>


### PR DESCRIPTION
## Description

This PR aims to address the enhancements proposed at this [issue](https://github.com/CookeJar87/alphabet-chaser/issues/25) by adding the correct styles for the elements around the word input component

## Solution
- Added margin and background styles for the proposed elements

## Screenshots
**Dark Mode:**

<img width="366" alt="Screenshot 2024-12-12 at 12 26 45" src="https://github.com/user-attachments/assets/b1227807-336a-4dc0-97f6-bf42df9593a3" />
<img width="360" alt="Screenshot 2024-12-12 at 12 26 48" src="https://github.com/user-attachments/assets/66d07fc4-e86f-4e00-908f-eb3585824e57" />

**Light Mode**

<img width="320" alt="Screenshot 2024-12-12 at 12 26 57" src="https://github.com/user-attachments/assets/e452e82b-cfd5-4e93-a741-56d12a54227f" />
<img width="346" alt="Screenshot 2024-12-12 at 12 27 00" src="https://github.com/user-attachments/assets/2615e0f7-35d8-498f-980c-b8b679d6624b" />
