### PR TITLE
Added Keyboard-movement

### DIFF
--- a/frontend/src/components/Controls.vue
+++ b/frontend/src/components/Controls.vue
@@ -11,8 +11,45 @@
 
 import { IonButton } from '@ionic/vue';
 import { useMovement } from '@/composables/useMovement';
+import { onMounted, onUnmounted, ref } from 'vue';
 
 const { left, right, up, down, stopMoving, movement } = useMovement();
+
+function handleKeyDown(event) {
+    console.log("Key pressed:", event.key);
+    switch (event.key) {
+        case 'ArrowLeft':
+        case 'a':
+            left();
+            break;
+        case 'ArrowRight':
+        case 'd':
+            right();
+            break;
+        case 'ArrowUp':
+        case 'w':
+            up();
+            break;
+        case 'ArrowDown':
+        case 's':
+            down();
+            break;
+    }
+}
+
+function handleKeyUp(event) {
+    stopMoving();
+}
+
+onMounted(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+});
+
+onUnmounted(() => {
+    document.removeEventListener('keydown', handleKeyDown);
+    document.removeEventListener('keyup', handleKeyUp);
+});
 
 </script>
 


### PR DESCRIPTION
Hi @CookeJar87 Please look into the this PR, I tried using _document.eventListeners_ to get the keystrokes globally irrespective of the element in focus .

This way the ealier _(when trying to use built-in keystrok method of vue)_ issue in which the **keystrokes would work only after the ion-botton are clicked atleast once** (this issue was related to the Div **divControl** not getting focus in **Control.vue**, it has something do to with ion-botton uses shadow DOM).

Well now it is working fine for me!
Please let me Know if it is good.
😁